### PR TITLE
Ensure imagenes dir exists on startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,6 +7,12 @@ const PORT = process.env.PORT || 3000;
 
 const registroRoutes = require('./registroRoutes');
 
+// Ensure the "imagenes" directory exists for uploads
+const imagenesPath = path.join(__dirname, 'imagenes');
+if (!fs.existsSync(imagenesPath)) {
+  fs.mkdirSync(imagenesPath, { recursive: true });
+}
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
## Summary
- initialize uploads directory if it doesn't exist

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684597404060832e8c0c1ef65aab696c