### PR TITLE
Fix docs path and code block closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ```
 
-faceorder/│
+zerowait/│
 ├── Dockerfile
 ├── server.js
 ├── registroRoutes.js
@@ -41,7 +41,7 @@ faceorder/│
 │   ├── models/               # Modelos preentrenados de face-api.js
 │   └── libs/                 # Librería face-api.min.js
 
-````
+```
 
 ---
 
@@ -62,7 +62,7 @@ faceorder/│
    ```bash
    git clone https://github.com/tuusuario/zerowait.git
    cd zerowait
-````
+```
 
 2. Construir la imagen:
 


### PR DESCRIPTION
## Summary
- update repo structure tree to `zerowait/`
- fix code block closing in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684599769e88832ebaaafee1d149306f