### PR TITLE
Add dark mode feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - 🔁 Flujo completo de confirmación de pedido o ingreso de un nuevo pedido.
 - 🧠 Uso de inteligencia artificial local (face-api.js) sin conexión a la nube.
 - 🔐 Toda la información se guarda localmente en archivos `.json` y carpetas persistidas por volumen de Docker.
+- 🌙 Interfaz con modo oscuro opcional.
 
 ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <h1>ZeroWait: Asistente Gastronómico Inteligente</h1>
+  <button id="toggleDark" style="float:right">Modo Oscuro</button>
   <div id="contenedor-video" style="position: relative; display: inline-block;">
     <video id="video" width="720" height="560" autoplay muted></video>
   </div>

--- a/public/main.js
+++ b/public/main.js
@@ -8,6 +8,22 @@ document.addEventListener('DOMContentLoaded', async () => {
   const pedidoNuevoDiv = document.getElementById('pedidoNuevoDiv');
   const inputNuevo = document.getElementById('pedidoNuevo');
   const enviarNuevo = document.getElementById('enviarPedidoNuevo');
+  const toggleDark = document.getElementById('toggleDark');
+
+  function applyTheme() {
+    const dark = localStorage.getItem('darkMode') === 'true';
+    document.body.classList.toggle('dark-mode', dark);
+    toggleDark.textContent = dark ? 'Modo Claro' : 'Modo Oscuro';
+  }
+
+  toggleDark.addEventListener('click', () => {
+    const isDark = !document.body.classList.contains('dark-mode');
+    document.body.classList.toggle('dark-mode', isDark);
+    localStorage.setItem('darkMode', isDark);
+    toggleDark.textContent = isDark ? 'Modo Claro' : 'Modo Oscuro';
+  });
+
+  applyTheme();
 
   let clienteActual = null;
   let yaSaludado = false;

--- a/public/style.css
+++ b/public/style.css
@@ -1,20 +1,35 @@
+:root {
+  --bg-color: #e6f7ff;
+  --text-color: #333;
+  --primary-color: #007acc;
+  --primary-hover: #005f99;
+}
+
 body {
   text-align: center;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background: #e6f7ff;
+  background: var(--bg-color);
   margin: 0;
   padding: 20px;
-  color: #333;
+  color: var(--text-color);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.dark-mode {
+  --bg-color: #121212;
+  --text-color: #f0f0f0;
+  --primary-color: #90caf9;
+  --primary-hover: #74b0e0;
 }
 
 h1 {
   margin-bottom: 20px;
   font-size: 28px;
-  color: #007acc;
+  color: var(--primary-color);
 }
 
 video {
-  border: 4px solid #007acc;
+  border: 4px solid var(--primary-color);
   border-radius: 10px;
   margin-top: 20px;
   box-shadow: 0 0 10px rgba(0,0,0,0.2);
@@ -32,8 +47,8 @@ button {
   padding: 12px 24px;
   font-size: 16px;
   margin: 12px 8px;
-  background-color: #007acc;
-  color: white;
+  background-color: var(--primary-color);
+  color: var(--text-color);
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -41,7 +56,7 @@ button {
 }
 
 button:hover {
-  background-color: #005f99;
+  background-color: var(--primary-hover);
 }
 
 input[type="text"] {
@@ -57,7 +72,7 @@ input[type="text"] {
 #ofertaEdad {
   margin-top: 25px;
   font-weight: bold;
-  color: #006699;
+  color: var(--primary-hover);
 }
 
 #contenedor-video {


### PR DESCRIPTION
## Summary
- add CSS variables for theming
- implement dark mode styles
- add dark mode toggle button in the interface
- persist theme preference in localStorage
- document new dark mode option

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845a5e9d604832e99814bf6ea278b32